### PR TITLE
Update WC_Centrobill getPMTransientKey cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Centrobill plugin for WooCommerce  
-Version 2.2.3
+Version 2.2.5
 
 ## Description
 CentroBill Payment Gateway plugin for WooCommerce   

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 *** Changelog ***
+= 2.2.5 - 2022-07-15 =
+* Update - Enable plugin availability for all stores
+
+= 2.2.4 - 2021-12-17 =
+* Fix - Wrong amount type (must be a number)
+
 = 2.2.3 - 2021-10-18 =
 * Fix - Displaying available payment methods on the checkout page affects other gateways
 * Fix - Link is now correctly in readme.txt

--- a/includes/class-wc-centrobill-api.php
+++ b/includes/class-wc-centrobill-api.php
@@ -270,7 +270,7 @@ if (!class_exists('WC_Centrobill_Api')) {
                     'price' => [
                         [
                             'offset' => $hasSubscriptionTrialPeriod ? $this->getOffsetParam($order) : '0d',
-                            'amount' => $renewalAmount ?: $amount,
+                            'amount' => ($renewalAmount !== null) ? floatval($renewalAmount) : floatval($amount),
                             'currency' => $order->get_currency(),
                             'repeat' => false,
                         ],
@@ -346,7 +346,7 @@ if (!class_exists('WC_Centrobill_Api')) {
                     'price' => [
                         [
                             'offset' => $hasSubscriptionTrialPeriod ? $this->getOffsetParam($order) : '0d',
-                            'amount' => $amount,
+                            'amount' => floatval($amount),
                             'currency' => $order->get_currency(),
                             'repeat' => false,
                         ],

--- a/includes/wc-centrobill-functions.php
+++ b/includes/wc-centrobill-functions.php
@@ -3,18 +3,12 @@
 defined('ABSPATH') || exit();
 
 /**
- * Check if the gateway is enabled and available in the user's country
+ * Check if the gateway is available
  *
  * @access public
  * @return bool
  */
 function wc_centrobill_is_valid_for_use() {
-    $currencies = apply_filters('woocommerce_centrobill_supported_currencies', ['RUB', 'USD', 'EUR', 'UAH']);
-
-    if (!in_array(get_woocommerce_currency(), $currencies, true)) {
-        return false;
-    }
-
     return true;
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, centrobill, payment gateway, online payment, credit card, sep
 Requires at least: 4.9.0
 Tested up to: 5.7.1
 Requires PHP: 5.6
-Stable tag: 2.2.3
+Stable tag: 2.2.5
 License: GPL v3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -119,6 +119,12 @@ Just in case, WooCommerce detailed manual about the tax setup is available by fo
 8. Tax. Product data.
 
 == Changelog ==
+= 2.2.5 - 2022-07-15 =
+* Update - Enable plugin availability for all stores
+
+= 2.2.4 - 2021-12-17 =
+* Fix - Wrong amount type (must be a number)
+
 = 2.2.3 - 2021-10-18 =
 * Fix - Displaying available payment methods on the checkout page affects other gateways
 * Fix - Link is now correctly in readme.txt
@@ -128,9 +134,6 @@ Just in case, WooCommerce detailed manual about the tax setup is available by fo
 
 = 2.2.1 - 2021-10-07 =
 * Update - Plugin version
-
-= 2.2.0 - 2021-10-06 =
-* Add - Crypto gateway
 
 [See changelog for all versions](https://raw.githubusercontent.com/Centrobill/wc-centrobill/master/changelog.txt)
 

--- a/wc-centrobill.php
+++ b/wc-centrobill.php
@@ -3,7 +3,7 @@
  * Plugin Name:     CentroBill Payment Gateway
  * Plugin URI:      https://centrobill.com
  * Description:     Allows you to use CentroBill payment gateway with the WooCommerce plugin
- * Version:         2.2.3
+ * Version:         2.2.5
  * Author:          CentroBill
  * Author URI:      https://centrobill.com/
  * License:         GPL v3 or later
@@ -14,7 +14,7 @@
  */
 defined('ABSPATH') || exit;
 
-define('WC_CENTROBILL_VERSION', '2.2.3');
+define('WC_CENTROBILL_VERSION', '2.2.5');
 define('WC_CENTROBILL_PLUGIN_PATH', untrailingslashit(plugin_dir_path(__FILE__)));
 define('WC_CENTROBILL_PLUGIN_URL', untrailingslashit(plugin_dir_url(__FILE__)));
 define('WC_CENTROBILL_PLUGIN_NAME', basename(dirname(__FILE__)) . '/' . basename(__FILE__));
@@ -195,7 +195,7 @@ if (!class_exists('WC_Centrobill')) {
          */
         public static function getPMTransientKey($email)
         {
-            return sprintf(SESSION_KEY_PM, md5($email . wc_centrobill_get_ip_address()));
+            return sprintf(SESSION_KEY_PM, md5($email));
         }
 
         private function __clone() {}

--- a/wc-centrobill.php
+++ b/wc-centrobill.php
@@ -195,7 +195,7 @@ if (!class_exists('WC_Centrobill')) {
          */
         public static function getPMTransientKey($email)
         {
-            return sprintf(SESSION_KEY_PM, md5($email));
+            return sprintf(SESSION_KEY_PM, md5($email . wc_centrobill_get_ip_address()));
         }
 
         private function __clone() {}


### PR DESCRIPTION
this change would avoid problems if users using an vpn or change networks (wifi => lte) getting the cached payment methodes